### PR TITLE
Fix error while running make

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,10 @@
 *.a
 
 src/libscalpel_test
+autom4te.cache/
+.deps/
+jni/.deps/
+src/.deps/
 
 # Images
 pendrive.img

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ sudo apt install automake autoconf libtool make tre-agrep libtre5 libtre-dev gcc
 ```bash
 # Linux/Mac OS X:
 ./bootstrap
-./configure 
+./configure --disable-shared
 make
 ```
 

--- a/src/input_reader.cpp
+++ b/src/input_reader.cpp
@@ -108,7 +108,7 @@ const char * scalpelInputGetId (ScalpelInputReader * const reader)
     return reader->id;
 }
 
-const char scalpelInputIsOpen (ScalpelInputReader * const reader) 
+char scalpelInputIsOpen (ScalpelInputReader * const reader) 
 {
     printVerbose("scalpelInputIsOpen()\n");
     return reader->isOpen;

--- a/src/input_reader.h
+++ b/src/input_reader.h
@@ -79,7 +79,7 @@ int scalpelInputGetError (ScalpelInputReader * const reader);
 
 //non-abstract methods
 const char* scalpelInputGetId (ScalpelInputReader * const reader);
-const char scalpelInputIsOpen(ScalpelInputReader * const reader);
+char scalpelInputIsOpen(ScalpelInputReader * const reader);
 
 
 /********************* FILE implementation of ScalpelInputReader **********************/

--- a/src/scalpel.cpp
+++ b/src/scalpel.cpp
@@ -667,7 +667,7 @@ int scalpel_carveSingleInput(ScalpelInputReader * const reader, const char * con
     const unsigned char handleEmbedded, const unsigned char organizeSubdirs,
     const unsigned char previewMode,
     const unsigned char carveWithMissingFooters,
-    const unsigned char noSearchOverlap) throw (std::runtime_error) {
+    const unsigned char noSearchOverlap) {
 
     if (!reader || ! confFilePath || ! outDir) {
         //invalid args

--- a/src/scalpel.h
+++ b/src/scalpel.h
@@ -303,7 +303,7 @@ extern int scalpel_carveSingleInput(ScalpelInputReader * const reader,
 		const unsigned char previewMode,
 		const unsigned char carveWithMissingFooters,
 		const unsigned char noSearchOverlap
-		) throw (std::runtime_error);
+		);
 
 typedef struct scalpelState {
     ScalpelInputReader * inReader;


### PR DESCRIPTION
# Description

The following error was encountered when running make

```bash
# 1st error
In file included from scalpel.h:72,
                 from libscalpel_test.cpp:23:
input_reader.h:82:1: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
   82 | const char scalpelInputIsOpen(ScalpelInputReader * const reader);
      | ^~~~~
In file included from libscalpel_test.cpp:23:
scalpel.h:306:19: error: ISO C++17 does not allow dynamic exception specifications
  306 |                 ) throw (std::runtime_error);
      |                   ^~~~~
# 2nd error
scalpel.cpp:670:42: error: ISO C++17 does not allow dynamic exception specifications
  670 |     const unsigned char noSearchOverlap) throw (std::runtime_error) {
      |                                          ^~~~~
```

# Update

* Removed unneeded const from input_reader (cpp and h) files
* Removed deprecated `throw (std::runtime_error)` in scalpel (cpp and h) files in `scalpel_carveSingleInput` function header
* Updated README to include correct build and make instructions
* Added some build and make files to .gitignore. More needs to be added later.
* See issue in resources below for more details on this work

# Resources

* [Fix error while running make](https://github.com/xPTM1219/scalpel/issues/3)